### PR TITLE
docs: expand LOG_LEVEL and ADDRESS documentation in config example

### DIFF
--- a/config.ini.example
+++ b/config.ini.example
@@ -13,13 +13,22 @@ USER = mqttuser
 PASS = mqttpass
 
 [TAPTAP]
-# Log level, possible values are error, warning, info, debug.
+# Controls verbosity of taptap-mqtt logging output.
+# Possible values: error, warning, info, debug.
+#   info:  Node status changes, MQTT events, errors, and warnings.
+#          ~2-3 MB/panel/day at UPDATE=5, much less at UPDATE=60.
+#   debug: Everything in info, plus per-poll telemetry data, power report
+#          events, node enumeration steps, and raw Modbus responses.
+#          ~400-500 MB/panel/day at UPDATE=5 — can quickly fill disk.
+# Recommended: "info" for normal operation. Use "debug" only for
+# short-term troubleshooting to avoid excessive disk usage.
 LOG_LEVEL = warning
 # Path to the taptap binary
 BINARY = ./taptap
 # Serial device to use like /dev/ACM0, set empty if using Modbus to Ethernet to Modbus converter.
-SERIAL = 
+SERIAL =
 # IP address of the Ethernet to Modbus convertor, set empty if using usb/serial Modus converter.
+# NOTE: ADDRESS must be present even when empty — taptap-mqtt.py requires it for config validation.
 ADDRESS = 192.168.1.50
 # IP port of the Ethernet to Modbus convertor, typically 502
 PORT = 502


### PR DESCRIPTION
Thanks for building this — it's been incredibly useful!

## Summary

- Expand the `LOG_LEVEL` comment with per-level descriptions and approximate 
  disk usage estimates, so users can make an informed choice before enabling 
  debug logging on systems with many panels.
- Add a note that `ADDRESS` must be present (even when empty) for serial setups, 
  since `taptap-mqtt.py` config validation requires it.

## Context

Running a 69-panel system with `LOG_LEVEL = debug` and `UPDATE = 5`, I measured 
roughly 400-500 MB/panel/day of log output. The existing one-line comment 
doesn't hint at this, which can catch people off guard on storage-constrained 
devices like a Raspberry Pi.

The `ADDRESS` note addresses a common gotcha when setting up serial-only 
configurations — removing the key entirely causes a validation error.